### PR TITLE
Switching to hardware encoder

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,7 +24,7 @@ dependencies:
     vars:
       ustreamer_interface: '0.0.0.0'
       ustreamer_port: 8001
-      ustreamer_encoder: omx
+      ustreamer_encoder: hw
       ustreamer_resolution: 1280x720
       ustreamer_workers: 16
       ustreamer_persistent: true


### PR DESCRIPTION
The HDMI dongle is delivering video that's already MJPEG encoded