### PR TITLE
Limit ustreamer and tinypilot to internal interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ tinypilot_user: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_repo: https://github.com/mtlynch/tinypilot.git
 tinypilot_repo_branch: master
-tinypilot_interface: '0.0.0.0'
+tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000
 tinypilot_hid_path: /dev/hidg0
 tinypilot_initialize_hid_script_path: /opt/enable-rpi-hid

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ tinypilot_user: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_repo: https://github.com/mtlynch/tinypilot.git
 tinypilot_repo_branch: master
-tinypilot_interface: '0.0.0.0'
+tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000
 tinypilot_hid_path: /dev/hidg0
 tinypilot_initialize_hid_script_path: /opt/enable-rpi-hid

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,7 +22,7 @@ galaxy_info:
 dependencies:
   - role: mtlynch.ustreamer
     vars:
-      ustreamer_interface: '0.0.0.0'
+      ustreamer_interface: '127.0.0.1'
       ustreamer_port: 8001
       ustreamer_encoder: hw
       ustreamer_resolution: 1280x720


### PR DESCRIPTION
nginx can still reverse proxy from port 80, but it's easier if we don't open more external ports.