### PR TITLE
Dropping assumption that hostname is tinypilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ tinypilot_repo_branch: master
 tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000
 tinypilot_hid_path: /dev/hidg0
-tinypilot_cors_origin: http://tinypilot
 tinypilot_initialize_hid_script_path: /opt/enable-rpi-hid
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,5 +7,4 @@ tinypilot_repo_branch: master
 tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000
 tinypilot_hid_path: /dev/hidg0
-tinypilot_cors_origin: http://tinypilot
 tinypilot_initialize_hid_script_path: /opt/enable-rpi-hid

--- a/templates/tinypilot.systemd.j2
+++ b/templates/tinypilot.systemd.j2
@@ -10,7 +10,6 @@ ExecStart={{ tinypilot_dir }}/venv/bin/python app/main.py
 Environment=HOST={{ tinypilot_interface }}
 Environment=PORT={{ tinypilot_port }}
 Environment=HID_PATH={{ tinypilot_hid_path }}
-Environment=CORS_ORIGIN={{ tinypilot_cors_origin }}
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
Adjusting the CORS settings so that we don't assume the hostname is tinypilot.

See also: https://github.com/mtlynch/tinypilot/pull/84