### PR TITLE
Relaxing architecture check to match aarch64

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: install HID USB gadget
   import_tasks: install_usb_gadget.yml
-  when: ansible_architecture.startswith("armv")
+  when: ansible_architecture.startswith("armv") or ansible_architecture == "aarch64"
 
 - name: install TinyPilot pre-requisite packages
   apt:


### PR DESCRIPTION
The arm check is mainly just to prevent the USB gadget from installing during the CI build, so this check loosens it so that it will run properly on aarch64 (64-bit ARM) systems.