### PR TITLE
Increasing number of proxy buffers

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -41,6 +41,8 @@ dependencies:
           root: "{{ tinypilot_dir }}"
           index: "index.html"
           extra_parameters: |
+            proxy_buffers 16 16k;
+            proxy_buffer_size 16k;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_http_version 1.1;


### PR DESCRIPTION
Without these directives, TinyPilot frequently has to write cache to disk.