### PR TITLE
Switching python3 to use the absolute python3 path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
 - name: find absolute path to python3
   shell: realpath $(which python3)
   register: realpath_python3
+  changed_when: false
 
 - name: save absolute path to python3
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,10 +47,24 @@
   notify:
     - restart TinyPilot service
 
+- name: find python3 path
+  shell: which python3
+  register: which_python3
+
+- name: convert python3 path to absolute path
+  stat:
+    path: "{{ which_python3.stdout }}"
+    follow: yes
+  register: python3_stat
+
+- name: save absolute path to python3
+  set_fact:
+    python3_abs_path: python3_stat.stat.path
+
 - name: create TinyPilot virtualenv
   pip:
     virtualenv: "{{ tinypilot_dir }}/venv"
-    virtualenv_command: "{{ ansible_python_interpreter }} -m venv venv"
+    virtualenv_command: "{{ python3_abs_path }} -m venv venv"
     requirements: "{{ tinypilot_dir }}/requirements.txt"
   notify:
     - restart TinyPilot service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: create TinyPilot virtualenv
   pip:
     virtualenv: "{{ tinypilot_dir }}/venv"
-    virtualenv_command: python3 -m venv venv
+    virtualenv_command: "{{ ansible_python_interpreter }} -m venv venv"
     requirements: "{{ tinypilot_dir }}/requirements.txt"
   notify:
     - restart TinyPilot service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,19 +47,13 @@
   notify:
     - restart TinyPilot service
 
-- name: find python3 path
-  shell: which python3
-  register: which_python3
-
-- name: convert python3 path to absolute path
-  stat:
-    path: "{{ which_python3.stdout }}"
-    follow: yes
-  register: python3_stat
+- name: find absolute path to python3
+  shell: realpath $(which python3)
+  register: realpath_python3
 
 - name: save absolute path to python3
   set_fact:
-    python3_abs_path: python3_stat.stat.path
+    python3_abs_path: realpath_python3.stdout
 
 - name: create TinyPilot virtualenv
   pip:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
 
 - name: save absolute path to python3
   set_fact:
-    python3_abs_path: realpath_python3.stdout
+    python3_abs_path: "{{ realpath_python3.stdout }}"
 
 - name: create TinyPilot virtualenv
   pip:


### PR DESCRIPTION
Otherwise, Ansible might use its own venv version of python3 to create a venv on the target.