### PR TITLE
Add tinypilot_external_port variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,12 @@ tinypilot_user: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_repo: https://github.com/mtlynch/tinypilot.git
 tinypilot_repo_branch: master
+# Port on which TinyPilot frontend listens (accessible from other hosts on the
+# network).
+tinypilot_external_port: 80
 tinypilot_interface: '127.0.0.1'
+# Port on which TinyPilot's backend listens (accessible only from
+# tinypilot_interface).
 tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
 tinypilot_provision_usb_gadget: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -41,7 +41,7 @@ dependencies:
           servers:
             - "127.0.0.1:{{ ustreamer_port }} fail_timeout=1s max_fails=600"
       nginx_vhosts:
-        - listen: "80 default_server"
+        - listen: "{{ tinypilot_external_port }} default_server"
           server_name: "tinypilot"
           root: "{{ tinypilot_dir }}"
           index: "index.html"


### PR DESCRIPTION
This allows the user to specify a port on which nginx will listen other than the default port 80.