### PR TITLE
Disable cache for HTML/CSS/JS

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -66,7 +66,17 @@ dependencies:
             location / {
               proxy_pass http://tinypilot;
             }
-            location ~* ^/.+\.(html|js|js.map|css|jpeg|png|ico)$ {
+            location ~* ^/.+\.(html|js|js.map|css)$ {
+              root "{{ tinypilot_dir }}/app/static";
+
+              # Disable caching
+              add_header Last-Modified $date_gmt;
+              add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+              if_modified_since off;
+              expires off;
+              etag off;
+            }
+            location ~* ^/.+\.(jpg|jpeg|png|ico)$ {
               root "{{ tinypilot_dir }}/app/static";
             }
       nginx_remove_default_vhost: true


### PR DESCRIPTION
The performance impact doesn't matter much, and it prevents us from getting into weird states where parts of the app go out of sync due to browser caching.