### PR TITLE
Unset device-specific defaults for uStreamer

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,11 +24,6 @@ dependencies:
     vars:
       ustreamer_interface: '127.0.0.1'
       ustreamer_port: 8001
-      ustreamer_encoder: hw
-      ustreamer_format: jpeg
-      ustreamer_resolution: 1920x1080
-      ustreamer_persistent: true
-      ustreamer_desired_fps: 30
       ustreamer_repo_version: v1.23
   - role: geerlingguy.nginx
     vars:


### PR DESCRIPTION
These defaults are specific to MS2109 HDMI to USB capture devices (the HDMI capture dongles that cost ~$10). Since TinyPilot now natively supports other capture devices, the default settings are now set in the TinyPilot installer:

https://github.com/mtlynch/tinypilot/pull/321