### PR TITLE
Temporarily switch to mtlynch fork of uStreamer

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,7 +24,10 @@ dependencies:
     vars:
       ustreamer_interface: '127.0.0.1'
       ustreamer_port: 8001
-      ustreamer_repo_version: v2.1
+      # Temporary workaround for a uStreamer bug that affects TinyPilot.
+      # See: https://github.com/mtlynch/ustreamer/commit/3ee535ce83a343ecae504a0a37efb08721126953
+      ustreamer_repo: https://github.com/mtlynch/ustreamer.git
+      ustreamer_repo_version: ignore-wait-return
   - role: geerlingguy.nginx
     vars:
       ustreamer_port: 8001


### PR DESCRIPTION
There's a bug in mainline uStreamer that affects encoding in OMX mode on TinyPilot. This change temporarily switches uStreamer's code to a fork that includes a workaround for the issue.