### PR TITLE
Remove deleted keyboard layout option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,5 @@ tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
 tinypilot_mouse_interface: /dev/hidg1
-tinypilot_keyboard_layout: qwerty
 tinypilot_enable_debug_logging: no
 tinypilot_provision_usb_gadget: yes

--- a/templates/tinypilot.systemd.j2
+++ b/templates/tinypilot.systemd.j2
@@ -11,7 +11,6 @@ Environment=HOST={{ tinypilot_interface }}
 Environment=PORT={{ tinypilot_port }}
 Environment=KEYBOARD_PATH={{ tinypilot_keyboard_interface }}
 Environment=MOUSE_PATH={{ tinypilot_mouse_interface }}
-Environment=KEYBOARD_LAYOUT={{ tinypilot_keyboard_layout }}
 {% if tinypilot_enable_debug_logging %}
 Environment=DEBUG=1
 {% endif %}


### PR DESCRIPTION
It was deleted from tinypilot in https://github.com/mtlynch/tinypilot/pull/355