### PR TITLE
Get rid of tinypilot_provision_usb_gadget variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,3 @@ tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
 tinypilot_mouse_interface: /dev/hidg1
 tinypilot_enable_debug_logging: no
-tinypilot_provision_usb_gadget: yes

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,5 +5,3 @@
     - name: "Include ansible-role-tinypilot"
       include_role:
         name: "ansible-role-tinypilot"
-      vars:
-        tinypilot_provision_usb_gadget: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,6 @@
 
 - name: install HID USB gadget
   import_tasks: install_usb_gadget.yml
-  when: tinypilot_provision_usb_gadget
 
 - name: install TinyPilot pre-requisite packages
   apt:


### PR DESCRIPTION
It's an artifact from when we couldn't install services in a Docker image, but that's fixed now. The fact that we skip this step in tets created test gaps that caused us to miss a real failure.