### PR TITLE
Enable install under proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,4 @@ tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
 tinypilot_mouse_interface: /dev/hidg1
 tinypilot_enable_debug_logging: no
-pip_args: ""
+tinypilot_pip_args: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
 tinypilot_mouse_interface: /dev/hidg1
 tinypilot_enable_debug_logging: no
+pip_args: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,7 +67,7 @@
     virtualenv: "{{ tinypilot_dir }}/venv"
     virtualenv_command: "{{ python3_abs_path }} -m venv venv"
     requirements: "{{ tinypilot_dir }}/requirements.txt"
-    extra_args: "{{ pip_args }}"
+    extra_args: "{{ tinypilot_pip_args }}"
   notify:
     - restart TinyPilot service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,7 @@
     virtualenv: "{{ tinypilot_dir }}/venv"
     virtualenv_command: "{{ python3_abs_path }} -m venv venv"
     requirements: "{{ tinypilot_dir }}/requirements.txt"
+    extra_args: "{{ pip_args }}"
   notify:
     - restart TinyPilot service
 


### PR DESCRIPTION
To install TinyPilot using proxy, I added "extra_args" on "create TinyPilot virtualenv" step.

When I tried to install using proxy, this step failed because pip command can't verify SSL certification.
I could solve this problem by adding "--trusted-host pypi.org" arguments on this step.

But it's not good for the user who doesn't use proxy, so I use pip_args variable.
If the user want to use proxy, pip_args is "--trusted-host pypi.org".
If not, `pip_args` is empty text.

pip_args is setten by quick-install.

Related: https://github.com/mtlynch/tinypilot/pull/402