### PR TITLE
Move TinyPilot's upgrade script to files/update

### DIFF
--- a/files/update
+++ b/files/update
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Echo commands to stdout.
+set -x
+
+# Treat undefined environment variables as errors.
+set -u
+
+# Exit on first error.
+set -e
+
+curl \
+  --silent \
+  --show-error \
+  https://raw.githubusercontent.com/mtlynch/tinypilot/master/quick-install | \
+    bash -

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,11 +31,25 @@
     system: yes
     create_home: no
 
-- name: enable passwordless sudo for shutdown command
+- name: copy update script
+  copy:
+    src: update
+    dest: "{{ tinypilot_privileged_dir }}/update"
+    owner: root
+    group: root
+    mode: '0700'
+
+- name: store passwordless sudo paths
+  set_fact:
+    sudo_paths:
+      - /sbin/shutdown
+      - "{{ tinypilot_privileged_dir }}/update"
+
+- name: enable tinypilot to execute a whitelist of commands as sudo
   lineinfile:
     dest: /etc/sudoers
     state: present
-    line: "{{ tinypilot_user }} ALL=(ALL) NOPASSWD: /sbin/shutdown"
+    line: "{{ tinypilot_user }} ALL=(ALL) NOPASSWD: {{ sudo_paths | join(', ') }}"
 
 - name: create TinyPilot folder
   file:


### PR DESCRIPTION
Note the upgrade -> update.

Also, combine both plays that were giving sudoers access to the tinypilot user
into a single one.

Addresses the Ansible part of https://github.com/mtlynch/tinypilot/issues/91.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/ansible-role-tinypilot/75)
<!-- Reviewable:end -->
