### PR TITLE
Remove stray conf file from TinyPilot Pro

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -1,4 +1,12 @@
 ---
+# TinyPilot Pro has two nginx configuration files, whereas TinyPilot Community
+# has just one. Remove the extra Pro file otherwise nginx will fail due to the
+# extra file if the user downgrades from Pro to free.
+- name: remove stray conf file from TinyPilot Pro
+  file:
+    path: /etc/nginx/sites-enabled/tinypilot.http.conf
+    state: absent
+
 - name: import nginx role
   import_role:
     name: geerlingguy.nginx


### PR DESCRIPTION
If a user downgrades from TinyPilot Pro to TinyPilot Community, there's a stray file left behind in the nginx configuration directory that causes nginx to fail to launch. This change gets rid of that stray file.

Fixes #78