### PR TITLE
Add silent mode to collect-debug-logs

### DIFF
--- a/files/collect-debug-logs
+++ b/files/collect-debug-logs
@@ -10,16 +10,13 @@ Collect debug logs.
 
     -h Display this help and exit.
     -q Run in silent mode without prompting user for inputs.
-    -u In silent mode, upload log file. If -q is provided and -u is not, the log file will not be uploaded.
-       If not in silent mode, -u is ignored.
 EOF
 }
 
 FLAG_SILENT_MODE=false
-FLAG_UPLOAD_LOGFILE=false
 
 # Parse command-line arguments.
-while getopts "hqu" opt; do
+while getopts "hq" opt; do
     case $opt in
         h)
             print_help
@@ -27,9 +24,6 @@ while getopts "hqu" opt; do
             ;;
         q)
             FLAG_SILENT_MODE=true
-            ;;
-        u)
-            FLAG_UPLOAD_LOGFILE=true
             ;;
         *)
             print_help >&2
@@ -100,12 +94,7 @@ echo "-------------------------------------"
 printf "\n\n"
 
 SHOULD_UPLOAD=false
-
-if [ "$FLAG_SILENT_MODE" == "true" ]; then
-    if [ "$FLAG_UPLOAD_LOGFILE" == "true" ]; then
-        SHOULD_UPLOAD=true
-    fi
-else
+if [ "$FLAG_SILENT_MODE" != "true" ]; then
     echo -n "Upload your log file? You can review it above to see what information it contains (y/n)? "
     read answer
     printf "\n"

--- a/files/collect-debug-logs
+++ b/files/collect-debug-logs
@@ -9,8 +9,8 @@ Usage: ${0##*/} [-hsu]
 Collect debug logs.
 
     -h Display this help and exit.
-    -s Run in silent mode without prompting user for inputs.
-    -u In silent mode, upload log file. If -s is provided and -u is not, the log file will not be uploaded.
+    -q Run in silent mode without prompting user for inputs.
+    -u In silent mode, upload log file. If -q is provided and -u is not, the log file will not be uploaded.
        If not in silent mode, -u is ignored.
 EOF
 }
@@ -19,13 +19,13 @@ FLAG_SILENT_MODE=false
 FLAG_UPLOAD_LOGFILE=false
 
 # Parse command-line arguments.
-while getopts "hsu" opt; do
+while getopts "hqu" opt; do
     case $opt in
         h)
             print_help
             exit
             ;;
-        s)
+        q)
             FLAG_SILENT_MODE=true
             ;;
         u)

--- a/files/collect-debug-logs
+++ b/files/collect-debug-logs
@@ -3,6 +3,41 @@
 # Exit on unset variable.
 set -u
 
+print_help() {
+    cat << EOF
+Usage: ${0##*/} [-hsu]
+Collect debug logs.
+
+    -h Display this help and exit.
+    -s Run in silent mode without prompting user for inputs.
+    -u In silent mode, upload log file. If -s is provided and -u is not, the log file will not be uploaded.
+       If not in silent mode, -u is ignored.
+EOF
+}
+
+FLAG_SILENT_MODE=false
+FLAG_UPLOAD_LOGFILE=false
+
+# Parse command-line arguments.
+while getopts "hsu" opt; do
+    case $opt in
+        h)
+            print_help
+            exit
+            ;;
+        s)
+            FLAG_SILENT_MODE=true
+            ;;
+        u)
+            FLAG_UPLOAD_LOGFILE=true
+            ;;
+        *)
+            print_help >&2
+            exit 1
+        # Add more options in the future.
+    esac
+done
+
 LOG_FILE=$(mktemp)
 echo "Writing diagnostic logs to $LOG_FILE"
 
@@ -64,10 +99,22 @@ cat "$LOG_FILE"
 echo "-------------------------------------"
 printf "\n\n"
 
-echo -n "Upload your log file? You can review it above to see what information it contains (y/n)? "
-read answer
-printf "\n"
-if [ "$answer" != "${answer#[Yy]}" ] ;then
+SHOULD_UPLOAD=false
+
+if [ "$FLAG_SILENT_MODE" == "true" ]; then
+    if [ "$FLAG_UPLOAD_LOGFILE" == "true" ]; then
+        SHOULD_UPLOAD=true
+    fi
+else
+    echo -n "Upload your log file? You can review it above to see what information it contains (y/n)? "
+    read answer
+    printf "\n"
+    if [ "$answer" != "${answer#[Yy]}" ]; then
+        SHOULD_UPLOAD=true
+    fi
+fi
+
+if [ "$SHOULD_UPLOAD" == "true" ]; then
     URL=$(cat "$LOG_FILE" | curl --silent --show-error --form 'sprunge=<-' http://sprunge.us)
     printf "Copy the following URL into your bug report:\n\n\t"
     printf "${URL}\n\n"


### PR DESCRIPTION
Closes https://github.com/mtlynch/ansible-role-tinypilot/issues/81.

 * Add a parser for command-line options
 * Add a help description (now that the script has options)
 * Respect -q/-u when determining if we should upload logs or not

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/ansible-role-tinypilot/82)
<!-- Reviewable:end -->
