### PR TITLE
Switch to softer workaround for idempotency test

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,7 +113,8 @@
     group: "{{ tinypilot_group }}"
     recurse: yes
   # TODO: Figure out why this fails idempotency otherwise.
-  changed_when: false
+  tags:
+    - molecule-idempotence-notest
 
 - name: install TinyPilot as a service
   template:


### PR DESCRIPTION
Using the molecule-idempotence-notest allows the task to behave normally except during the molecule idempotency test.