### PR TITLE
Set a dependency on an explicit uStreamer version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,5 @@
 ---
 - src: mtlynch.ustreamer
+  version: 1.0.0
 - src: geerlingguy.nginx
   version: 2.8.0


### PR DESCRIPTION
If we don't do this, then Ansible might cache an old version and not recognize that a new version is available. I wish it would just check whether the local HEAD matched the remote HEAD, because it's going to be a pain constantly updating this number.