### PR TITLE
Revert "Set a dependency on an explicit uStreamer version"

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,4 @@
 ---
 - src: mtlynch.ustreamer
-  version: 1.0.0
 - src: geerlingguy.nginx
   version: 2.8.0


### PR DESCRIPTION
Reverts mtlynch/ansible-role-tinypilot#98

This seems like it doesn't achieve what we want. ansible will still use a cached version even if we specify a new version, so we have to use --force anyway.