### PR TITLE
Redirect debug log status output to stderr

### DIFF
--- a/files/collect-debug-logs
+++ b/files/collect-debug-logs
@@ -33,7 +33,7 @@ while getopts "hq" opt; do
 done
 
 LOG_FILE=$(mktemp)
-echo "Writing diagnostic logs to $LOG_FILE"
+echo "Writing diagnostic logs to $LOG_FILE" >&2
 
 echo "TinyPilot log dump" >> "$LOG_FILE"
 echo "https://tinypilotkvm.com" >> "$LOG_FILE"
@@ -42,49 +42,49 @@ printf "\n\n" >> "$LOG_FILE"
 
 echo "Software versions" >> "$LOG_FILE"
 
-echo "Checking TinyPilot version..."
+echo "Checking TinyPilot version..." >&2
 cd /opt/tinypilot
 printf "TinyPilot version: %s %s\n" "$(git describe --tags)" "$(git rev-parse --short HEAD)" >> "$LOG_FILE"
 
-echo "Checking uStreamer version..."
+echo "Checking uStreamer version..." >&2
 cd /opt/ustreamer
 printf "uStreamer version: %s %s\n" "$(git describe --tags)" "$(git rev-parse --short HEAD)" >> "$LOG_FILE"
 
-echo "Checking OS version..."
+echo "Checking OS version..." >&2
 printf "OS version: %s\n" "$(uname -a)" >> "$LOG_FILE"
 printf "\n" >> "$LOG_FILE"
 
-echo "Checking for voltage issues..."
+echo "Checking for voltage issues..." >&2
 echo "voltage logs" >> "$LOG_FILE"
 sudo journalctl -xe | grep -i "voltage"  >> "$LOG_FILE"
 printf "\n" >> "$LOG_FILE"
 
-echo "Checking TinyPilot configuration..."
+echo "Checking TinyPilot configuration..." >&2
 printf "TinyPilot configuration\n" >> "$LOG_FILE"
 cat /lib/systemd/system/tinypilot.service >> "$LOG_FILE"
 printf "\n" >> "$LOG_FILE"
 
-echo "Checking TinyPilot logs..."
+echo "Checking TinyPilot logs..." >&2
 printf "TinyPilot logs\n" >> "$LOG_FILE"
 sudo journalctl -u tinypilot | tail -n 200 >> "$LOG_FILE"
 printf "\n" >> "$LOG_FILE"
 
-echo "Checking TinyPilot updater logs..."
+echo "Checking TinyPilot updater logs..." >&2
 printf "TinyPilot update logs\n" >> "$LOG_FILE"
 $(dirname $0)/read-update-log | tail -n 200 >> "$LOG_FILE"
 printf "\n" >> "$LOG_FILE"
 
-echo "Checking uStreamer configuration..."
+echo "Checking uStreamer configuration..." >&2
 printf "uStreamer configuration\n" >> "$LOG_FILE"
 cat /lib/systemd/system/ustreamer.service >> "$LOG_FILE"
 printf "\n" >> "$LOG_FILE"
 
-echo "Checking uStreamer logs..."
+echo "Checking uStreamer logs..." >&2
 printf "uStreamer logs\n" >> "$LOG_FILE"
 sudo journalctl -u ustreamer | tail -n 80 >> "$LOG_FILE"
 printf "\n" >> "$LOG_FILE"
 
-echo "Checking nginx logs..."
+echo "Checking nginx logs..." >&2
 echo "nginx logs" >> "$LOG_FILE"
 sudo journalctl -u nginx >> "$LOG_FILE"
 printf "\n\n" >> "$LOG_FILE"
@@ -93,10 +93,10 @@ printf "\n\n" >> "$LOG_FILE"
 sudo tail -n 30 /var/log/nginx/access.log >> "$LOG_FILE"
 printf "\n" >> "$LOG_FILE"
 
-printf "Your log:\n\n"
+printf "Your log:\n\n" >&2
 cat "$LOG_FILE"
-echo "-------------------------------------"
-printf "\n\n"
+echo "-------------------------------------" >&2
+printf "\n\n" >&2
 
 SHOULD_UPLOAD=false
 if [ "$FLAG_SILENT_MODE" != "true" ]; then
@@ -113,7 +113,7 @@ if [ "$SHOULD_UPLOAD" == "true" ]; then
     printf "Copy the following URL into your bug report:\n\n\t"
     printf "${URL}\n\n"
 else
-    echo "Log file not uploaded."
-    printf "If you decide to share it, run:\n\n"
-    printf "  cat $LOG_FILE | curl --silent --show-error --form 'sprunge=<-' http://sprunge.us\n\n"
+    echo "Log file not uploaded." >&2
+    printf "If you decide to share it, run:\n\n" >&2
+    printf "  cat $LOG_FILE | curl --silent --show-error --form 'sprunge=<-' http://sprunge.us\n\n" >&2
 fi


### PR DESCRIPTION
It's a little hacky to redirect regular output to stderr, but otherwise the output of the debug log gets mixed up with the output of the log collection in the same stream.