### PR TITLE
Always restart the TinyPilot systemd service.

### DIFF
--- a/templates/tinypilot.systemd.j2
+++ b/templates/tinypilot.systemd.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=TinyPilot - RPi-based virtual KVM
 After=syslog.target network.target
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple


### PR DESCRIPTION
This PR disables the rate limiting applied to failed systemd service starts.

According to the [systemd.unit docs](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=interval):
> Units which are started more than *burst* times within an *interval* time interval are not permitted to start any more.
>...
>set it to 0 to disable any kind of rate limiting

So `Restart=always` together with `StartLimitIntervalSec=0` will restart the service no matter what the exit code is.

[Demo video.](https://www.loom.com/share/8a7fe589d06449818805c8451ed09884)

Fixes #86 