### PR TITLE
Set the Host header when upgrading to a WebSocket connection.

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -35,6 +35,7 @@
             proxy_pass http://tinypilot;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $http_host;
           }
           location /state {
             proxy_pass http://ustreamer;


### PR DESCRIPTION
When users access TinyPilot from a different URL (other than `http://tinypilot/`), it breaks the WebSocket connection.

# Investigation process

Based on your [suggestion](https://github.com/mtlynch/tinypilot/issues/99#issuecomment-797739350) to look at the [`flask-socketio` docs](https://flask-socketio.readthedocs.io/en/latest/#using-nginx-as-a-websocket-reverse-proxy) on how to handle WebSocket connections, the given config fixed the issue.

I didn't really understand why it fixed the issue so I did some more debugging and the fix boils down to setting the `Host` header (that includes the schema) within the location block.
```
location /socket.io {
    ...
    proxy_set_header Host $http_host;
    ...
}
```

This is strange because we do [set the `Host` header in the global server block](https://github.com/jdeanwallace/ansible-role-tinypilot/blob/b5a1b7410029125b32f301143fd4f1fa09d4514b/tasks/nginx.yml#L30). I assumed that the [socketio location block](https://github.com/jdeanwallace/ansible-role-tinypilot/blob/b5a1b7410029125b32f301143fd4f1fa09d4514b/tasks/nginx.yml#L34) would absorb the headers set in the parent server block, but it didn't in this case.

The best conclusion I could come to was that when upgrading the HTTP connection to use WebSockets you also need to explicitly set the `Host` header, based on this extract from the [nginx docs](https://www.nginx.com/blog/websocket-nginx/):
> For NGINX to send the Upgrade request from the client to the backend server, the Upgrade and Connection headers must be set explicitly, as in this example:
>
> ```
> location /wsapp/ {
>     proxy_pass http://wsbackend;
>     proxy_http_version 1.1;
>     proxy_set_header Upgrade $http_upgrade;
>     proxy_set_header Connection "Upgrade";
>     proxy_set_header Host $host;
> }
> ```
> 

I'm not 100% satisfied with this conclusion, but at least the fix works.

---

[Demo video](https://www.loom.com/share/f81d86f78edc43588ee269823076e506).

Fixes the [Restrict CORS origins for socket.io connections issue](https://github.com/mtlynch/tinypilot/issues/99).