### PR TITLE
Remove command-line flags from update script

### DIFF
--- a/files/update
+++ b/files/update
@@ -9,38 +9,6 @@ set -u
 # Exit on first error.
 set -e
 
-FLAG_RELEASE_VERSION=''
-
-print_help() {
-  cat << EOF
-Usage: ${0##*/} [-h] [-r release]
-Update TinyPilot.
-  -h Display this help and exit.
-  -r Update TinyPilot to a specific release version or commit ID.
-EOF
-}
-
-# Parse command-line arguments.
-while getopts "hr:" opt; do
-  case $opt in
-    r)
-      FLAG_RELEASE_VERSION="${OPTARG}"
-      ;;
-    h)
-      print_help
-      exit
-      ;;
-    *)
-      print_help >&2
-      exit 1
-  esac
-done
-
-# If release version is set, export it so the bash script below can use it.
-if [[ ! -z "${FLAG_RELEASE_VERSION}" ]]; then
-  export TINYPILOT_INSTALL_VARS="tinypilot_repo_branch=${FLAG_RELEASE_VERSION}"
-fi
-
 curl \
   --silent \
   --show-error \


### PR DESCRIPTION
Originally, the idea was that the caller would specify the update version by calling update with a particular version flag. Instead, we ended up just setting the appropriate role variable in /home/tinypilot/settings.yml when we need to target a specific version, so this is dead code.