### PR TITLE
Move tinypilot_user var from defaults to vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Available variables are listed below, along with default values (see [defaults/m
 
 ```yaml
 tinypilot_group: tinypilot
-tinypilot_user: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_repo: https://github.com/mtlynch/tinypilot.git
 tinypilot_repo_branch: master

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 tinypilot_group: tinypilot
-tinypilot_user: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged
 tinypilot_repo: https://github.com/mtlynch/tinypilot.git

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,5 @@
+---
+# TinyPilot's quick-install script (which it uses for installation and updates)
+# relies on the tinypilot user being named "tinypilot" so changing this value
+# will break updates.
+tinypilot_user: tinypilot


### PR DESCRIPTION
This gives the variable higher precedence and indicates to users that they shouldn't change the value.