### PR TITLE
Update nginx dependency source in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tinypilot_keyboard_interface: /dev/hidg0
 ## Dependencies
 
 * [mtlynch.ustreamer](https://github.com/mtlynch/ansible-role-ustreamer)
-* [geerlingguy.nginx](https://github.com/geerlingguy/ansible-role-nginx)
+* [tiny-pilot.nginx](https://github.com/tiny-pilot/ansible-role-nginx)
 
 ## Example Playbook
 


### PR DESCRIPTION
We switched to a fork of geerlingguy's nginx in 69f00a4a2aa327d118f22a3138b5dbdb932901c1, but we forgot to update the reference in the README.