### PR TITLE
Configure mass storage and add scripts for mounting

### DIFF
--- a/files/init-usb-gadget
+++ b/files/init-usb-gadget
@@ -122,6 +122,17 @@ echo -ne \\xC0           # END_COLLECTION
 } >> "$D"
 cp "$D" "${MOUSE_FUNCTIONS_DIR}/report_desc"
 
+# Mass Storage
+# See here for more info:
+# - https://www.kernel.org/doc/html/latest/usb/mass-storage.html
+# - https://www.kernel.org/doc/Documentation/ABI/testing/configfs-usb-gadget-mass-storage
+MASS_STORAGE_FUNCTIONS_DIR="functions/mass_storage.0"
+mkdir -p "${MASS_STORAGE_FUNCTIONS_DIR}"
+echo 1 > "${MASS_STORAGE_FUNCTIONS_DIR}/stall"
+echo 0 > "${MASS_STORAGE_FUNCTIONS_DIR}/lun.0/cdrom"
+echo 1 > "${MASS_STORAGE_FUNCTIONS_DIR}/lun.0/ro"
+echo 0 > "${MASS_STORAGE_FUNCTIONS_DIR}/lun.0/nofua"
+
 CONFIG_INDEX=1
 CONFIGS_DIR="configs/c.${CONFIG_INDEX}"
 mkdir -p "$CONFIGS_DIR"
@@ -133,6 +144,7 @@ echo "Config ${CONFIG_INDEX}: ECM network" > "${CONFIGS_STRINGS_DIR}/configurati
 
 ln -s "$KEYBOARD_FUNCTIONS_DIR" "${CONFIGS_DIR}/"
 ln -s "$MOUSE_FUNCTIONS_DIR" "${CONFIGS_DIR}/"
+ln -s "$MASS_STORAGE_FUNCTIONS_DIR" "${CONFIGS_DIR}/"
 ls /sys/class/udc > UDC
 
 chmod 777 /dev/hidg0

--- a/files/mass-storage-mount
+++ b/files/mass-storage-mount
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Presents a backing file as device to the USB host.
+
+# Exit on unset variable.
+set -u
+
+# Exit on first error.
+set -e
+
+readonly USB_GADGET_PATH="/sys/kernel/config/usb_gadget/g1"
+readonly MASS_STORAGE_FUNCTIONS_DIR="${USB_GADGET_PATH}/functions/mass_storage.0"
+
+print_help() {
+  cat << EOF
+Usage: ${0##*/} [-h] backing_file
+  Presents a backing file as device to the USB host.
+  -h Display this help and exit.
+EOF
+}
+
+# Parse command-line arguments.
+while getopts 'h' opt; do
+  case "${opt}" in
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help >&2
+      exit 1
+  esac
+done
+
+# Ensure 'backing_file' is given and it exists.
+shift $((OPTIND - 1))
+if (( $# == 0 )); then
+  echo 'Input parameter missing: backing_file' >&2
+  exit 1
+fi
+readonly BACKING_FILE="$1"
+if [[ ! -f "${BACKING_FILE}" ]]; then
+  echo "No such file: ${BACKING_FILE}" >&2
+  exit 1
+fi
+
+# Set backing file.
+echo "${BACKING_FILE}" > "${MASS_STORAGE_FUNCTIONS_DIR}/lun.0/file"


### PR DESCRIPTION
I was familiarising myself with configfs and mounting a mass storage today. (So far it’s the basic setup and a script for mounting a flash drive, but it’s all still WIP.)

One question I was running into: we want to support both CD-ROM and flash-drive mode, right? (See [the `cdrom` option](https://www.kernel.org/doc/html/latest/usb/mass-storage.html#module-parameters).) Just double-checking, because CD-ROMs seem to be a bit more “unruly” code-wise, so e.g. swapping out the backing file appears to require rebinding the gadget to the UDC, see [here](https://github.com/tiny-pilot/tinypilot-pro/pull/1/files#diff-48f39e05f5ab360b86cceb5f82c2a2a13f1e2c6cad14601b4b362698bad1af0bR28). Not super bad, but in case we wouldn’t want it it’s a bit simpler.