### PR TITLE
Use the latest version of ansible-role-nginx

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,3 @@
 ---
 - src: mtlynch.ustreamer
 - src: https://github.com/tiny-pilot/ansible-role-nginx
-  version: 2.8.1


### PR DESCRIPTION
Since we now use the tinypilot fork of ansible-role-nginx, we don't need to worry about it changing out from under us unexpectedly.