### PR TITLE
Revert "Bump ansible from 2.9.10 to 2.10.0 in /molecule"

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -8,7 +8,7 @@
 
 # Direct dependencies
 
-ansible==2.10.0
+ansible==2.9.10
 molecule==3.2.3
 molecule-docker==0.2.4
 


### PR DESCRIPTION
Reverts mtlynch/ansible-role-tinypilot#127

Wasn't able to update the Ansible version in the main library. See: https://github.com/mtlynch/tinypilot/pull/631