### PR TITLE
Add update-video-settings to list of sudo paths

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,7 @@
       - "{{ tinypilot_privileged_dir }}/collect-debug-logs"
       - "{{ tinypilot_privileged_dir }}/read-update-log"
       - "{{ tinypilot_privileged_dir }}/update"
+      - "{{ tinypilot_privileged_dir }}/update-video-settings"
 
 - name: enable tinypilot to execute a whitelist of commands as sudo
   lineinfile:


### PR DESCRIPTION
TinyPilot web UI requires acesss to this script, so we need to enable sudo execution.