### PR TITLE
Fix mouse HID descriptor report_length.

### DIFF
--- a/files/init-usb-gadget
+++ b/files/init-usb-gadget
@@ -78,7 +78,7 @@ MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
 mkdir -p "$MOUSE_FUNCTIONS_DIR"
 echo 0 > "${MOUSE_FUNCTIONS_DIR}/protocol"
 echo 0 > "${MOUSE_FUNCTIONS_DIR}/subclass"
-echo 5 > "${MOUSE_FUNCTIONS_DIR}/report_length"
+echo 7 > "${MOUSE_FUNCTIONS_DIR}/report_length"
 # Write the report descriptor
 D=$(mktemp)
 {


### PR DESCRIPTION
On the mouse HID descriptor, the total `report_length` doesn't match the sum all the individual `report_size * report_count` values.

My calculation based on the [mouse HID descriptor](https://github.com/mtlynch/ansible-role-tinypilot/blob/e0971a7770eedbee4b50e7f201354f4ffca12f48/files/init-usb-gadget#L85-L121):
```
Buttons =                   REPORT_SIZE (1)  * REPORT_COUNT (8) = 1 byte
X, Y absolute coordinates = REPORT_SIZE (16) * REPORT_COUNT (2) = 4 bytes
vertical wheel =            REPORT_SIZE (8)  * REPORT_COUNT (1) = 1 byte
horizontal wheel =          REPORT_SIZE (8)  * REPORT_COUNT (1) = 1 byte
------------------------------------------------------------------------------
                                            Total report length = 7 bytes
```


https://user-images.githubusercontent.com/6730025/118194030-fc642a80-b448-11eb-8476-3fcd4193270e.mov

Fixes https://github.com/mtlynch/tinypilot/issues/693