### PR TITLE
Update references to ansible-role-ustreamer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ tinypilot_keyboard_interface: /dev/hidg0
 
 ## Dependencies
 
-* [mtlynch.ustreamer](https://github.com/mtlynch/ansible-role-ustreamer)
+* [tiny-pilot.ustreamer](https://github.com/tiny-pilot/ansible-role-ustreamer)
 * [tiny-pilot.nginx](https://github.com/tiny-pilot/ansible-role-nginx)
 
 ## Example Playbook

--- a/files/update-video-settings
+++ b/files/update-video-settings
@@ -61,7 +61,7 @@ pushd "${INSTALLER_DIR}"
 . venv/bin/activate
 
 readonly PLAYBOOK=$(mktemp --suffix ".yml")
-readonly USTREAMER_ROLE_NAME="mtlynch.ustreamer"
+readonly USTREAMER_ROLE_NAME="ansible-role-ustreamer"
 echo "- hosts: localhost
   connection: local
   become: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,3 @@
 ---
-- src: mtlynch.ustreamer
+- src: https://github.com/tiny-pilot/ansible-role-ustreamer
 - src: https://github.com/tiny-pilot/ansible-role-nginx

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -1,7 +1,7 @@
 ---
 - name: import uStreamer role
   import_role:
-    name: mtlynch.ustreamer
+    name: ansible-role-ustreamer
   vars:
     ustreamer_interface: '127.0.0.1'
     ustreamer_port: 8001


### PR DESCRIPTION
They're no longer in the mtlynch namespace, and are now part of the tiny-pilot Github org.